### PR TITLE
fix MarkerState rotation

### DIFF
--- a/osm-compose/src/main/java/com/utsman/osmandcompose/MarkerState.kt
+++ b/osm-compose/src/main/java/com/utsman/osmandcompose/MarkerState.kt
@@ -12,7 +12,7 @@ import org.osmdroid.views.overlay.Marker
 
 class MarkerState(geoPoint: GeoPoint = GeoPoint(0.0, 0.0), rotation: Float = 0f) {
     var geoPoint: GeoPoint by mutableStateOf(geoPoint)
-    var rotation: Float by mutableStateOf(0f)
+    var rotation: Float by mutableStateOf(rotation)
 
     private val markerState: MutableState<Marker?> = mutableStateOf(null)
 


### PR DESCRIPTION
There is a bug in `MarkerState` where the `rotation` attribute is not used at all, instead a fixed value of `0f` is used. 

This PR fixes this bug.