### PR TITLE
`OverlayManagerState`: fix `setMap` function

### DIFF
--- a/osm-compose/src/main/java/com/utsman/osmandcompose/OverlayManagerState.kt
+++ b/osm-compose/src/main/java/com/utsman/osmandcompose/OverlayManagerState.kt
@@ -17,6 +17,7 @@ class OverlayManagerState(private var _overlayManager: OverlayManager?) {
     private var _mapView: MapView? = null
     fun setMap(mapView: MapView) {
         _overlayManager = mapView.overlayManager
+        _mapView = mapView
     }
 
     fun getMap(): MapView {


### PR DESCRIPTION
There is a bug in `setMap` where the `_mapView` variable is not updated. As a result, it is not possible to get the map for, e.g., adding a `MyLocationNewOverlay` overlay to the map.

This PR solves the issue.